### PR TITLE
ISSUE#5: now using placeholder image for broken urls

### DIFF
--- a/components/MovieDisplay.js
+++ b/components/MovieDisplay.js
@@ -31,7 +31,11 @@ const MovieDisplay = ({ movies }) => (
               <Card
                 title={title}
                 releaseDate={release_date}
-                posterLink={`http://image.tmdb.org/t/p/w500${poster_path}`}
+                posterLink={
+                  poster_path === null
+                    ? '/fine.jpg'
+                    : `http://image.tmdb.org/t/p/w500${poster_path}`
+                }
               />
             </a>
           </Link>

--- a/cypress/integration/landing_page.spec.js
+++ b/cypress/integration/landing_page.spec.js
@@ -31,4 +31,11 @@ describe('Landing page hydration', () => {
         expect(20).to.be.equals(lengthOfOptions);
       });
   });
+
+  it('movies have images', () => {
+    cy.get('[data-cy=moviecard')
+      .find('img')
+      .should('have.attr', 'src')
+      .should('include', '.jpg');
+  });
 });

--- a/cypress/integration/search.spec.js
+++ b/cypress/integration/search.spec.js
@@ -23,12 +23,21 @@ describe('Searching functionality and SRR', () => {
       expect(focused).to.have.attr('data-cy', 'searchBar');
     });
   });
+});
 
-  it('20 movies are present', () => {
+describe('Content exists', () => {
+  it('movies are present', () => {
     cy.get('[data-cy=moviecard]')
       .its('length')
       .then((lengthOfOptions) => {
-        expect(20).to.be.equals(lengthOfOptions);
+        expect(lengthOfOptions).to.be.greaterThan(0);
       });
+  });
+
+  it('movies have images', () => {
+    cy.get('[data-cy=moviecard')
+      .find('img')
+      .should('have.attr', 'src')
+      .should('include', '.jpg');
   });
 });

--- a/pages/movies/[id].js
+++ b/pages/movies/[id].js
@@ -43,7 +43,10 @@ const StyledDetails = styled.div`
 
 const Movie = ({ movieDetails }) => {
   const { title, runtime, genres, overview } = movieDetails;
-  const posterLink = `http://image.tmdb.org/t/p/w500${movieDetails.poster_path}`;
+  const posterLink =
+    movieDetails.poster_path === null
+      ? '/fine.jpg'
+      : `http://image.tmdb.org/t/p/w500${movieDetails.poster_path}`;
   const releaseDate = movieDetails.release_date;
   const stars = movieDetails.credits.cast.slice(0, 3);
 


### PR DESCRIPTION
Landing page & search page both utilize MovieDisplay component. Checks now in place.
Move details page also have checks. 